### PR TITLE
Remove max_size parameter

### DIFF
--- a/examples/display_frame_pygame_display_simpletest.py
+++ b/examples/display_frame_pygame_display_simpletest.py
@@ -14,7 +14,7 @@ from circuitpython_display_frame import Frame
 display = PyGameDisplay(icon="", width=800, height=600)
 
 # Make the display context
-main_group = displayio.Group(max_size=10)
+main_group = displayio.Group()
 
 
 example_frame = Frame(20, 20, display.width // 3, display.height - 40)


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

This was tested using `PyGameDisplay` in `Ubuntu 20.04`

